### PR TITLE
Fixes Lerp tween speed to match Vanilla 2.8

### DIFF
--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -215,7 +215,7 @@ class MainMenuState extends MusicBeatState
 
 	override function update(elapsed:Float)
 	{
-		FlxG.camera.followLerp = CoolUtil.camLerpShit(0.6);
+		FlxG.camera.followLerp = CoolUtil.camLerpShit(0.035);
 
 		if (FlxG.sound.music.volume < 0.8)
 			FlxG.sound.music.volume += 0.5 * FlxG.elapsed;


### PR DESCRIPTION
Fixing MainMenuState's lerp for the bg to match with Vanilla 2.8